### PR TITLE
Add AWS Memcached ElastiCache module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# terraform-aws-memcached-elasticache
+
+A Terraform module to create an Amazon Web Services (AWS) Memcached ElastiCache cluster.
+
+## Usage
+
+```javascript
+module "memcached_elasticache" {
+  source = "github.com/azavea/terraform-aws-memcached-elasticache"
+
+  vpc_id = "vpc-20f74844"
+  vpc_cidr_block = "10.0.0.0/16"
+
+  cache_name = "cache"
+  cache_nodes = "2"
+  engine_version = "1.4.24"
+  instance_type = "cache.t2.micro"
+  maintenance_window = "sun:05:00-sun:06:00"
+
+  private_subnet_ids = "subnet-4a887f3c,subnet-76dae35d"
+
+  alarm_actions = "arn:aws:sns..."
+}
+```
+
+## Variables
+
+- `vpc_id` - ID of VPC meant to house the cache
+- `vpc_cidr_block` - CIDR block of VPC
+- `cache_name` - Name used as ElastiCache cluster ID
+- `cache_nodes` - Number of nodes in the cache cluster
+- `engine_version` - Cache engine version (default: `1.4.24`)
+- `instance_type` - Instance type for cache instance (default: `cache.t2.micro`)
+- `maintenance_window` - 60 minute time window to reserve for maintenance
+  (default: `sun:05:00-sun:06:00`)
+- `private_subnet_ids` - Comma delimited list of private subnet IDs
+- `alarm_actions` - Comma delimited list of ARNs to be notified via CloudWatch
+
+## Outputs
+
+- `cache_security_group_id` - Security group ID of the cache cluster
+- `configuration_endpoint` - Configuration endpoint to allow for host discovery

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,95 @@
+#
+# Security group resources
+#
+
+resource "aws_security_group" "memcached" {
+  vpc_id = "${var.vpc_id}"
+
+  tags {
+    Name = "sgCacheCluster"
+  }
+}
+
+resource "aws_security_group_rule" "memcached_ingress" {
+    type = "ingress"
+    from_port = 11211
+    to_port = 11211
+    protocol = "tcp"
+    cidr_blocks = ["${var.vpc_cidr_block}"]
+
+    security_group_id = "${aws_security_group.memcached.id}"
+}
+
+resource "aws_security_group_rule" "memcached_egress" {
+    type = "egress"
+    from_port = 11211
+    to_port = 11211
+    protocol = "tcp"
+    cidr_blocks = ["${var.vpc_cidr_block}"]
+
+    security_group_id = "${aws_security_group.memcached.id}"
+}
+
+#
+# ElastiCache resources
+#
+
+resource "aws_elasticache_cluster" "memcached" {
+  cluster_id = "${var.cache_name}"
+  engine = "memcached"
+  engine_version = "${var.engine_version}"
+  maintenance_window = "${var.maintenance_window}"
+  node_type = "${var.instance_type}"
+  num_cache_nodes = "${var.cache_nodes}"
+  parameter_group_name = "default.memcached1.4"
+  port = "11211"
+  subnet_group_name = "${aws_elasticache_subnet_group.default.name}"
+  security_group_ids = ["${aws_security_group.memcached.id}"]
+
+  tags {
+    Name = "CacheCluster"
+  }
+}
+
+resource "aws_elasticache_subnet_group" "default" {
+  name = "${var.cache_name}-subnet-group"
+  description = "Private subnets for the ElastiCache instances"
+  subnet_ids = ["${split(",", var.private_subnet_ids)}"]
+}
+
+#
+# CloudWatch resources
+#
+
+resource "aws_cloudwatch_metric_alarm" "cpu" {
+  alarm_name = "alarmCacheClusterCPUUtilization"
+  alarm_description = "Cache cluster CPU utilization"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods = "1"
+  metric_name = "CPUUtilization"
+  namespace = "AWS/ElastiCache"
+  period = "300"
+  statistic = "Average"
+  threshold = "75"
+  dimensions {
+    CacheClusterId = "${aws_elasticache_cluster.memcached.id}"
+  }
+  alarm_actions = ["${split(",", var.alarm_actions)}"]
+}
+
+resource "aws_cloudwatch_metric_alarm" "memory_free" {
+  alarm_name = "alarmCacheClusterFreeableMemory"
+  alarm_description = "Cache cluster freeable memory"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods = "1"
+  metric_name = "FreeableMemory"
+  namespace = "AWS/ElastiCache"
+  period = "60"
+  statistic = "Average"
+  # 10MB in bytes
+  threshold = "10000000"
+  dimensions {
+    CacheClusterId = "${aws_elasticache_cluster.memcached.id}"
+  }
+  alarm_actions = ["${split(",", var.alarm_actions)}"]
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,7 @@
+output "cache_security_group_id" {
+  value = "${aws_security_group.memcached.id}"
+}
+
+output "configuration_endpoint" {
+  value = "${aws_elasticache_cluster.memcached.configuration_endpoint}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,21 @@
+variable "vpc_id" { }
+variable "vpc_cidr_block" { }
+
+variable "cache_name" { }
+variable "cache_nodes" {
+  default = "1"
+}
+variable "engine_version" {
+  default = "1.4.24"
+}
+variable "instance_type" {
+  default = "cache.t2.micro"
+}
+variable "maintenance_window" {
+  # SUN 01:00AM-02:00AM ET
+  default = "sun:05:00-sun:06:00"
+}
+
+variable "private_subnet_ids" { }
+
+variable "alarm_actions" { }


### PR DESCRIPTION
Adds a Terraform module that creates a Amazon Web Services (AWS) Memcached ElastiCache made up of:

- Cache security group
- Memcached ElastiCache instance
- CloudWatch alarms (CPU, RAM)

---

**Testing**

I used a Terraform file like this one to test:

```hcl
provider "aws" {
  region = "us-east-1"
}

module "vpc" {
  source = "github.com/azavea/terraform-aws-vpc?ref=0.3.0"

  name                       = "joker"
  region                     = "us-east-1"
  key_name                   = "joker"
  cidr_block                 = "10.0.0.0/16"
  external_access_cidr_block = "216.158.51.82/32"
  private_subnet_cidr_blocks = "10.0.1.0/24,10.0.3.0/24"
  public_subnet_cidr_blocks  = "10.0.0.0/24,10.0.2.0/24"
  availability_zones         = "us-east-1b,us-east-1d"
  nat_ami                    = "ami-303b1458"
  nat_instance_type          = "t2.nano"
  nat_egress_ports           = "80,443"
  bastion_ami                = "ami-ff02509a"
  bastion_instance_type      = "t2.nano"
}

module "memcached_elasticache" {
  source = "/Users/hcastro/Projects/terraform-aws-memcached-elasticache"

  vpc_id = "${module.vpc.id}"
  vpc_cidr_block = "${module.vpc.cidr_block}"

  cache_name = "cache"
  cache_nodes = "2"
  engine_version = "1.4.24"
  instance_type = "cache.t2.micro"
  maintenance_window = "sun:05:00-sun:06:00"

  private_subnet_ids = "${module.vpc.private_subnet_ids}"

  alarm_actions = "arn:aws:sns:us-east-1:715496170458:NotifyMe"
}

output "joker" {
    value = "${module.memcached_elasticache.configuration_endpoint}"
}
```