### PR TITLE
Add support for Memcached ElastiCache cache cluster

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2016 Azavea Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,65 @@
+# terraform-aws-memcached-elasticache
+
+A Terraform module to create an Amazon Web Services (AWS) Memcached ElastiCache cluster.
+
+## Usage
+
+```hcl
+resource "aws_sns_topic" "global" {
+  ...
+}
+
+resource "aws_elasticache_subnet_group" "memcached" {
+  ...
+}
+
+resource "aws_elasticache_parameter_group" "memcached" {
+  ...
+}
+
+module "cache" {
+  source = "github.com/azavea/terraform-aws-memcached-elasticache"
+  
+  vpc_id                     = "vpc-20f74844"
+  cache_identifier           = "cache"
+  desired_clusters           = "1"
+  instance_type              = "cache.t2.micro"
+  engine_version             = "1.4.33"
+  parameter_group            = "${aws_elasticache_parameter_group.memcached.name}"
+  subnet_group               = "${aws_elasticache_subnet_group.memcached.name}"
+  maintenance_window         = "sun:02:30-sun:03:30"
+  notification_topic_arn     = "${aws_sns_topic.global.arn}"
+
+  alarm_cpu_threshold_percent  = "75"
+  alarm_memory_threshold_bytes = "10000000"
+  alarm_actions                = ["${aws_sns_topic.global.arn}"]
+
+  project     = "Unknown"
+  environment = "Unknown"
+}
+```
+
+## Variables
+
+- `vpc_id` - ID of VPC meant to house the cache
+- `project` - Name of the project making use of the cluster (default: `Unknown`)
+- `environment` - Name of environment the cluster is targeted for (default: `Unknown`)
+- `cache_identifier` - Name used as ElastiCache cluster ID
+- `desired_clusters` - Number of cache clusters
+- `instance_type` - Instance type for cache instance (default: `cache.t2.micro`)
+- `engine_version` - Cache engine version (default: `3.2.4`)
+- `parameter_group` - Cache parameter group name (default: `memcached1.4`)
+- `subnet_group` - Cache subnet group name
+- `maintenance_window` - Time window to reserve for maintenance
+- `notification_topic_arn` - ARN to notify when cache events occur
+- `alarm_cpu_threshold_percent` - CPU alarm threshold as a percentage (default: `75`)
+- `alarm_memory_threshold_bytes` - Free memory alarm threshold in bytes (default: `10000000`)
+- `alarm_actions` - ARN to be notified via CloudWatch when alarm thresholds are triggered
+
+## Outputs
+
+- `id` - The cache cluster ID
+- `cache_security_group_id` - Security group ID of the cache cluster
+- `port` - Port of cache cluster
+- `configuration_endpoint` - Configuration endpoint to allow for host discovery
+- `endpoint` - Public DNS name of cache cluster

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,76 @@
+#
+# Security group resources
+#
+resource "aws_security_group" "memcached" {
+  vpc_id = "${var.vpc_id}"
+
+  tags {
+    Name        = "sgCacheCluster"
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
+  }
+}
+
+#
+# ElastiCache resources
+#
+resource "aws_elasticache_cluster" "memcached" {
+  cluster_id             = "${lower(var.cache_identifier)}"
+  engine                 = "memcached"
+  engine_version         = "${var.engine_version}"
+  node_type              = "${var.instance_type}"
+  num_cache_nodes        = "${var.desired_clusters}"
+  parameter_group_name   = "${var.parameter_group}"
+  subnet_group_name      = "${var.subnet_group}"
+  security_group_ids     = ["${aws_security_group.memcached.id}"]
+  maintenance_window     = "${var.maintenance_window}"
+  notification_topic_arn = "${var.notification_topic_arn}"
+  port                   = "11211"
+
+  tags {
+    Name        = "CacheCluster"
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
+  }
+}
+
+#
+# CloudWatch resources
+#
+resource "aws_cloudwatch_metric_alarm" "cache_cpu" {
+  alarm_name          = "alarm${var.environment}MemcachedCacheClusterCPUUtilization"
+  alarm_description   = "Memcached cluster CPU utilization"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ElastiCache"
+  period              = "300"
+  statistic           = "Average"
+
+  threshold = "${var.alarm_cpu_threshold_percent}"
+
+  dimensions {
+    CacheClusterId = "${aws_elasticache_cluster.memcached.id}"
+  }
+
+  alarm_actions = ["${var.alarm_actions}"]
+}
+
+resource "aws_cloudwatch_metric_alarm" "cache_memory" {
+  alarm_name          = "alarm${var.environment}MemcachedCacheClusterFreeableMemory"
+  alarm_description   = "Memcached cluster freeable memory"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "FreeableMemory"
+  namespace           = "AWS/ElastiCache"
+  period              = "60"
+  statistic           = "Average"
+
+  threshold = "${var.alarm_memory_threshold_bytes}"
+
+  dimensions {
+    CacheClusterId = "${aws_elasticache_cluster.memcached.id}"
+  }
+
+  alarm_actions = ["${var.alarm_actions}"]
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,19 @@
+output "id" {
+  value = "${aws_elasticache_cluster.memcached.id}"
+}
+
+output "cache_security_group_id" {
+  value = "${aws_security_group.memcached.id}"
+}
+
+output "port" {
+  value = "11211"
+}
+
+output "configuration_endpoint" {
+  value = "${aws_elasticache_cluster.memcached.configuration_endpoint}"
+}
+
+output "endpoint" {
+  value = "${aws_elasticache_cluster.memcached.cluster_address}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,46 @@
+variable "project" {
+  default = "Unknown"
+}
+
+variable "environment" {
+  default = "Unknown"
+}
+
+variable "vpc_id" {}
+
+variable "cache_identifier" {}
+
+variable "parameter_group" {
+  default = "memcached1.4"
+}
+
+variable "subnet_group" {}
+
+variable "maintenance_window" {}
+
+variable "desired_clusters" {
+  default = "1"
+}
+
+variable "instance_type" {
+  default = "cache.t2.micro"
+}
+
+variable "engine_version" {
+  default = "1.4.33"
+}
+
+variable "notification_topic_arn" {}
+
+variable "alarm_cpu_threshold_percent" {
+  default = "75"
+}
+
+variable "alarm_memory_threshold_bytes" {
+  # 10MB
+  default = "10000000"
+}
+
+variable "alarm_actions" {
+  type = "list"
+}


### PR DESCRIPTION
Add the core components necessary for a Memcached ElastiCache cache cluster:

- Variable sized ElastiCache cache cluster
- Cache cluster security group with no rules
- CloudWatch Alarms for CPU and memory utilization