### PR TITLE
Allow cluster replacement when instance type changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ module "cache" {
 - `vpc_id` - ID of VPC meant to house the cache
 - `project` - Name of the project making use of the cluster (default: `Unknown`)
 - `environment` - Name of environment the cluster is targeted for (default: `Unknown`)
-- `cache_identifier` - Name used as ElastiCache cluster ID
+- `cache_identifier` - Name used as ElastiCache cluster ID, truncated at 16 characters
 - `desired_clusters` - Number of cache clusters
 - `instance_type` - Instance type for cache instance (default: `cache.t2.micro`)
 - `engine_version` - Cache engine version (default: `3.2.4`)

--- a/main.tf
+++ b/main.tf
@@ -15,11 +15,16 @@ resource "aws_security_group" "memcached" {
 # ElastiCache resources
 #
 resource "aws_elasticache_cluster" "memcached" {
-  cluster_id             = "${lower(var.cache_identifier)}"
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  cluster_id             = "${format("%.16s-%.4s", lower(var.cache_identifier), md5(var.instance_type))}"
   engine                 = "memcached"
   engine_version         = "${var.engine_version}"
   node_type              = "${var.instance_type}"
   num_cache_nodes        = "${var.desired_clusters}"
+  az_mode                = "${var.desired_clusters == 1 ? "single-az" : "cross-az"}"
   parameter_group_name   = "${var.parameter_group}"
   subnet_group_name      = "${var.subnet_group}"
   security_group_ids     = ["${aws_security_group.memcached.id}"]


### PR DESCRIPTION
When the instance type for a cache cluster changes, ensure that a replacement cluster is created before the existing one is destroyed. Also, encode the instance type in the cluster ID in a way that ensures it won't go over the 20 character limit.

Lastly, set the `az_mode` attribute appropriately based on the number of nodes in the cache cluster.

---

**Testing**

See: https://github.com/azavea/raster-foundry-deployment/pull/95