### PR TITLE
Upgrade module to support Terraform 0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0
+
+- Add support for Terraform 0.12; 0.12 is now the minimum supported version.
+
 ## 1.0.0
 
 - Replace cache cluster when instance type is changed.

--- a/main.tf
+++ b/main.tf
@@ -2,12 +2,12 @@
 # Security group resources
 #
 resource "aws_security_group" "memcached" {
-  vpc_id = "${var.vpc_id}"
+  vpc_id = var.vpc_id
 
-  tags {
+  tags = {
     Name        = "sgCacheCluster"
-    Project     = "${var.project}"
-    Environment = "${var.environment}"
+    Project     = var.project
+    Environment = var.environment
   }
 }
 
@@ -19,23 +19,27 @@ resource "aws_elasticache_cluster" "memcached" {
     create_before_destroy = true
   }
 
-  cluster_id             = "${format("%.16s-%.4s", lower(var.cache_identifier), md5(var.instance_type))}"
+  cluster_id = format(
+    "%.16s-%.4s",
+    lower(var.cache_identifier),
+    md5(var.instance_type),
+  )
   engine                 = "memcached"
-  engine_version         = "${var.engine_version}"
-  node_type              = "${var.instance_type}"
-  num_cache_nodes        = "${var.desired_clusters}"
-  az_mode                = "${var.desired_clusters == 1 ? "single-az" : "cross-az"}"
-  parameter_group_name   = "${var.parameter_group}"
-  subnet_group_name      = "${var.subnet_group}"
-  security_group_ids     = ["${aws_security_group.memcached.id}"]
-  maintenance_window     = "${var.maintenance_window}"
-  notification_topic_arn = "${var.notification_topic_arn}"
+  engine_version         = var.engine_version
+  node_type              = var.instance_type
+  num_cache_nodes        = var.desired_clusters
+  az_mode                = var.desired_clusters == 1 ? "single-az" : "cross-az"
+  parameter_group_name   = var.parameter_group
+  subnet_group_name      = var.subnet_group
+  security_group_ids     = [aws_security_group.memcached.id]
+  maintenance_window     = var.maintenance_window
+  notification_topic_arn = var.notification_topic_arn
   port                   = "11211"
 
-  tags {
+  tags = {
     Name        = "CacheCluster"
-    Project     = "${var.project}"
-    Environment = "${var.environment}"
+    Project     = var.project
+    Environment = var.environment
   }
 }
 
@@ -52,13 +56,13 @@ resource "aws_cloudwatch_metric_alarm" "cache_cpu" {
   period              = "300"
   statistic           = "Average"
 
-  threshold = "${var.alarm_cpu_threshold_percent}"
+  threshold = var.alarm_cpu_threshold_percent
 
-  dimensions {
-    CacheClusterId = "${aws_elasticache_cluster.memcached.id}"
+  dimensions = {
+    CacheClusterId = aws_elasticache_cluster.memcached.id
   }
 
-  alarm_actions = ["${var.alarm_actions}"]
+  alarm_actions = var.alarm_actions
 }
 
 resource "aws_cloudwatch_metric_alarm" "cache_memory" {
@@ -71,11 +75,12 @@ resource "aws_cloudwatch_metric_alarm" "cache_memory" {
   period              = "60"
   statistic           = "Average"
 
-  threshold = "${var.alarm_memory_threshold_bytes}"
+  threshold = var.alarm_memory_threshold_bytes
 
-  dimensions {
-    CacheClusterId = "${aws_elasticache_cluster.memcached.id}"
+  dimensions = {
+    CacheClusterId = aws_elasticache_cluster.memcached.id
   }
 
-  alarm_actions = ["${var.alarm_actions}"]
+  alarm_actions = var.alarm_actions
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,9 @@
 output "id" {
-  value = "${aws_elasticache_cluster.memcached.id}"
+  value = aws_elasticache_cluster.memcached.id
 }
 
 output "cache_security_group_id" {
-  value = "${aws_security_group.memcached.id}"
+  value = aws_security_group.memcached.id
 }
 
 output "port" {
@@ -11,9 +11,10 @@ output "port" {
 }
 
 output "configuration_endpoint" {
-  value = "${aws_elasticache_cluster.memcached.configuration_endpoint}"
+  value = aws_elasticache_cluster.memcached.configuration_endpoint
 }
 
 output "endpoint" {
-  value = "${aws_elasticache_cluster.memcached.cluster_address}"
+  value = aws_elasticache_cluster.memcached.cluster_address
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -6,17 +6,21 @@ variable "environment" {
   default = "Unknown"
 }
 
-variable "vpc_id" {}
+variable "vpc_id" {
+}
 
-variable "cache_identifier" {}
+variable "cache_identifier" {
+}
 
 variable "parameter_group" {
   default = "memcached1.4"
 }
 
-variable "subnet_group" {}
+variable "subnet_group" {
+}
 
-variable "maintenance_window" {}
+variable "maintenance_window" {
+}
 
 variable "desired_clusters" {
   default = "1"
@@ -30,7 +34,8 @@ variable "engine_version" {
   default = "1.4.33"
 }
 
-variable "notification_topic_arn" {}
+variable "notification_topic_arn" {
+}
 
 variable "alarm_cpu_threshold_percent" {
   default = "75"
@@ -42,5 +47,6 @@ variable "alarm_memory_threshold_bytes" {
 }
 
 variable "alarm_actions" {
-  type = "list"
+  type = list(string)
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
## Overview

Following the instructions outlined in the Terraform documentation, update the module's configuration to support Terraform 0.12. Despite containing minor changes, this is expected to cause a major version bump, because the changes are not backwards compatible.

Fixes #7

## Testing

This was required by and tested in the context of https://github.com/open-apparel-registry/open-apparel-registry/pull/2138 